### PR TITLE
Don't open dev tools on npm start

### DIFF
--- a/main.js
+++ b/main.js
@@ -15,8 +15,8 @@ function createWindow () {
   // and load the index.html of the app.
   mainWindow.loadURL(`file://${__dirname}/index.html`)
 
-  // Open the DevTools.
-  mainWindow.webContents.openDevTools()
+  // Open the DevTools. (uncomment the line below)
+  // mainWindow.webContents.openDevTools()
 
   // Emitted when the window is closed.
   mainWindow.on('closed', function () {


### PR DESCRIPTION
Trace is good enough. Let us prevent the call to `openDevTools()` so that it opens ready to do some tracing. In the future developers can work on the code base and just uncomment the line.